### PR TITLE
GitHub Actions で自動ビルド

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-linux-amd64:
+    name: ubuntu-18.04-gcc
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          make
+          sudo make install
+      - name: package
+        run: |
+          ref='${{ github.ref }}'
+          tag=$(echo $ref | perl -e "print pop @{[split '/', <>]}")
+
+          mkdir -p $tag/bin
+          cp /usr/bin/kinx $tag/bin/kinx
+          cp -r /usr/bin/kinxlib $tag/lib
+          tar zcvf linux-amd64.tar.gz $tag/
+      - name: upload archive
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-linux-amd64
+          path: linux-amd64.tar.gz
+
+  build-windows-x64:
+    name: windows-2019-vc
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          make.cmd
+      - name: package
+        shell: pwsh
+        run: Compress-Archive -Path kinx.exe,*.dll,*.ins,lib/ -DestinationPath windows-x64.zip -Force -Verbose
+      - name: upload archive
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-windows-x64
+          path: windows-x64.zip
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    outputs:
+      release_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+
+  upload-assets:
+    name: upload assets
+    needs:
+      - release
+      - build-linux-amd64
+      - build-windows-x64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        job: [build-linux-amd64, build-windows-x64]
+        include:
+          - job: build-linux-amd64
+            asset_path: linux-amd64.tar.gz
+            asset_name: package_linux-amd64.tar.gz
+            content_type: application/gzip
+          - job: build-windows-x64
+            asset_path: windows-x64.zip
+            asset_name: package_win64.zip
+            content_type: application/zip
+    steps:
+      - name: download archive
+        id: download_archive
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ matrix.job }}
+      - name: upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.release_url }}
+          asset_path: ${{ matrix.job }}/${{ matrix.asset_path }}
+          asset_name: ${{ matrix.asset_name }}
+          asset_content_type: ${{ matrix.content_type }}


### PR DESCRIPTION
Linux 版 と Windows 版、それぞれ 64bit でのビルドを自動で行う Action を作成してみました。
`v*` の名前を持つタグが push される度に走り、以下を行います。

- 同じ名前の releases を draft で作成
- 作成した releases に `gcc` (Ubuntu 18.04) でビルドしたバイナリを追加
- 作成した releases に `nmake` (Windows Server 2019) でビルドしたバイナリを追加

ここまで自動でやってくれます。  
![releases](https://user-images.githubusercontent.com/1135891/82556712-40f61680-9ba5-11ea-8ecb-16329a9fc199.png)

ただし、何故か Windows 版のビルドに長大な時間がかかります。  
具体的には `src/ir_exec.c` のコンパイルにかかる時間が Linux 版は 20秒未満なのに対して Windows 版は約 45分かかります。  
（これはバラつきがあり、短いと 25分程度、長いと 50分程度ですが、30回程度 CI を走らせた限りほとんどの場合で 45分程度になりました）

実際に走った CI のログ: https://github.com/htsign/kinx/actions/runs/111357011

- Linux の場合  
  ![linux-amd64](https://user-images.githubusercontent.com/1135891/82554447-e6f35200-9ba0-11ea-8baa-54477cdf133e.png)
- Windows の場合  
  ![windows-x64](https://user-images.githubusercontent.com/1135891/82556648-215eee00-9ba5-11ea-8c2b-3434ebcfa217.png)
