### PR TITLE
.gitattributes 追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# workaround for Kinx highlight
+*.kx          text linguist-language=CoffeeScript
+.spectest     text linguist-language=JSON linguist-detectable
+
+# exclude files in directories below from github stats
+src/extlib/libcurl/**   linguist-vendored
+src/extlib/libxml2/**   linguist-vendored
+src/extlib/onig/**      linguist-vendored
+src/extlib/openssl/**   linguist-vendored
+src/extlib/sqlite/**    linguist-vendored
+src/extlib/zip/**       linguist-vendored
+src/extlib/*/README.md  -linguist-vendored
+src/extlib/*/x64/**     -linguist-vendored binary


### PR DESCRIPTION
`.gitattributes` の叩き台を作りました。

`*.kx` がハイライトされるようになります。
同様に `.spectest` も JSON 扱いとなってハイライトされます。（濃色なので本当に着色されているか判断に困りますが…）

`src/extlib/` のいくつかのディレクトリに含まれるファイル群を [language stats bar](https://saraford.net/2017/01/01/how-to-see-the-language-percentage-breakdown-of-a-repo-001/) の統計から除外し、かつ `diff` に表示させなくする（らしいです。未確認）ようにします。
「`diff` に出なくなる」というのは功罪併せ持つと考えられるため、特に注意深くレビューいただけると幸甚です。

参考: https://github.com/github/linguist#overrides