### PR TITLE
自動テスト修正

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,7 +49,7 @@ jobs:
 
             const debug = core.getInput('debug') === 'true';
 
-            const log = obj => debug && console.log(obj);
+            const log = (...args) => debug && console.log(...args);
             const listFilesAsync = (dir = '.') => promisify(fs.readdir)(dir);
             const readFileAsync = (file, enc = 'utf8') => promisify(fs.readFile)(file, enc);
 
@@ -70,7 +70,9 @@ jobs:
                 linkPattern = /\[([^\]]+)\]\s*\(([^\)]+\.md)\)/,
                 interpreter = 'kinx',
                 ignoreFiles = [],
-              } = require('.spectest');
+              } = JSON.parse(await readFileAsync('.spectest'));
+
+              ignoreFiles.forEach((x, i) => ignoreFiles[i] = path.normalize(x));
               log('.spectest info', { root, topLevelFilePattern, linkPattern, interpreter, ignoreFiles });
 
               if (interpreter !== 'kinx') throw new UnnecessaryException;
@@ -81,31 +83,32 @@ jobs:
               log({ files, targets });
               if (!targets.length) throw new UnnecessaryException;
 
-              // exclude ingored files
-              for (const file of ignoreFiles) {
-                diffs.delete(path.normalize(file));
-              }
-
               // extract written links
               const pickLinks = async (file, pickedLinks) => { // (string, Set<string>) => void
                 const text = await readFileAsync(file);
-                const matches = text.match(RegExp(linkPattern, 'g'));
+                const matches = text.match(RegExp(linkPattern, 'g')) || [];
                 const newFiles = matches
                   .map(link => link.match(RegExp(linkPattern))[2])
-                  .filter(uri => !pickedFiles.has(uri));
+                  .map(uri => path.join(root, uri))
+                  .filter(uri => fs.existsSync(uri) && !(ignoreFiles.includes(uri) || pickedLinks.has(uri)));
 
-                newFiles.forEach(x => pickedFiles.add(x));
-                for (const file of newFiles) {
-                  await pickLinks(file, pickedFiles);
+                newFiles.forEach(x => pickedLinks.add(x));
+                for (const newFile of newFiles) {
+                  await pickLinks(newFile, pickedLinks);
                 }
               };
               const links = new Set();
               for (const target of targets) {
-                await pickLinks(target, links);
+                await pickLinks(path.join(root, target), links);
+              }
+
+              // exclude ingored files
+              for (const file of ignoreFiles) {
+                links.delete(file);
               }
               log({ links });
 
-              const b = diffs.some(diff => links.has(diff));
+              const b = [...diffs].some(diff => links.has(diff));
               if (!b) throw new UnnecessaryException;
               return b;
             }

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -71,6 +71,7 @@ jobs:
                 interpreter = 'kinx',
                 ignoreFiles = [],
               } = require('.spectest');
+              log('.spectest info', { root, topLevelFilePattern, linkPattern, interpreter, ignoreFiles });
 
               if (interpreter !== 'kinx') throw new UnnecessaryException;
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -58,9 +58,11 @@ jobs:
             }
 
             try {
+              if (!fs.existsSync('.spectest')) throw new UnnecessaryException;
+
               const diffs = new Set(JSON.parse(process.env.DIFF_FILES));
               log({ diffs });
-              if (!diffs.has('.spectest')) throw new UnnecessaryException;
+              if (!diffs.size) throw new UnnecessaryException;
 
               const {
                 root,
@@ -68,7 +70,7 @@ jobs:
                 linkPattern = /\[([^\]]+)\]\s*\(([^\)]+\.md)\)/,
                 interpreter = 'kinx',
                 ignoreFiles = [],
-              } = require(spec);
+              } = require('.spectest');
 
               if (interpreter !== 'kinx') throw new UnnecessaryException;
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -91,7 +91,7 @@ jobs:
                 const matches = text.match(RegExp(linkPattern, 'g')) || [];
                 const newFiles = matches
                   .map(link => link.match(RegExp(linkPattern))[2])
-                  .map(uri => path.join(root, uri))
+                  .map(uri => path.join(path.dirname(file), uri))
                   .filter(uri => fs.existsSync(uri) && !(ignoreFiles.includes(uri) || pickedLinks.has(uri)));
 
                 newFiles.forEach(x => pickedLinks.add(x));
@@ -102,11 +102,6 @@ jobs:
               const links = new Set();
               for (const target of targets) {
                 await pickLinks(path.join(root, target), links);
-              }
-
-              // exclude ingored files
-              for (const file of ignoreFiles) {
-                links.delete(file);
               }
               log({ links });
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,19 +1,123 @@
 name: Unit Test
 
-on:
-  push:
-      paths: ['**.kx', '**/.spectest', 'doc/spec/**.md']
-  pull_request:
-      paths: ['**.kx', '**/.spectest', 'doc/spec/**.md']
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: retrieve diff filenames
+        id: diff_filenames
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          debug: true
+          script: |
+            const { compare, pull_request } = context.payload;
+
+            let base, head;
+            switch (context.eventName) {
+              case 'push':
+                [, base, head] = compare.match(/\/compare\/([0-9a-f]+)\.\.\.([0-9a-f]+)$/);
+                break;
+              case 'pull_request':
+                base = pull_request.base.sha;
+                head = pull_request.head.sha;
+                break;
+            }
+
+            if (base && head) {
+              const { owner, repo } = context.repo;
+              const diffs = await github.repos.compareCommits({ owner, repo, base, head });
+              return diffs.data.files.map(file => file.filename);
+            }
+            return [];
+
+      - name: read .spectest files
+        id: linked_files
+        uses: actions/github-script@v1
+        env:
+          DIFF_FILES: ${{ steps.diff_filenames.outputs.result }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          debug: true
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { promisify } = require('util');
+
+            const debug = core.getInput('debug') === 'true';
+
+            const log = obj => debug && console.log(obj);
+            const listFilesAsync = (dir = '.') => promisify(fs.readdir)(dir);
+            const readFileAsync = (file, enc = 'utf8') => promisify(fs.readFile)(file, enc);
+
+            class UnnecessaryException extends Error {
+              constructor() { super('no need unittest in this commit/PR') }
+            }
+
+            try {
+              const diffs = new Set(JSON.parse(process.env.DIFF_FILES));
+              log({ diffs });
+              if (!diffs.has('.spectest')) throw new UnnecessaryException;
+
+              const {
+                root,
+                topLevelFilePattern = /(README|CONTENTS)\.md/,
+                linkPattern = /\[([^\]]+)\]\s*\(([^\)]+\.md)\)/,
+                interpreter = 'kinx',
+                ignoreFiles = [],
+              } = require(spec);
+
+              if (interpreter !== 'kinx') throw new UnnecessaryException;
+
+              // get testfiles from 'root'
+              const files = await listFilesAsync(root);
+              const targets = files.filter(file => RegExp(topLevelFilePattern).test(file));
+              log({ files, targets });
+              if (!targets.length) throw new UnnecessaryException;
+
+              // exclude ingored files
+              for (const file of ignoreFiles) {
+                diffs.delete(path.normalize(file));
+              }
+
+              // extract written links
+              const pickLinks = async (file, pickedLinks) => { // (string, Set<string>) => void
+                const text = await readFileAsync(file);
+                const matches = text.match(RegExp(linkPattern, 'g'));
+                const newFiles = matches
+                  .map(link => link.match(RegExp(linkPattern))[2])
+                  .filter(uri => !pickedFiles.has(uri));
+
+                newFiles.forEach(x => pickedFiles.add(x));
+                for (const file of newFiles) {
+                  await pickLinks(file, pickedFiles);
+                }
+              };
+              const links = new Set();
+              for (const target of targets) {
+                await pickLinks(target, links);
+              }
+              log({ links });
+
+              const b = diffs.some(diff => links.has(diff));
+              if (!b) throw new UnnecessaryException;
+              return b;
+            }
+            catch (e) {
+              if (e instanceof UnnecessaryException) {
+                console.log(e.message);
+                return false;
+              }
+            }
+
       - name: install
+        if: steps.linked_files.outputs.result == 'true'
         run: |
           make
           sudo make install
       - name: run test
+        if: steps.linked_files.outputs.result == 'true'
         run: kinx --exec:spectest -v

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -114,6 +114,7 @@ jobs:
                 console.log(e.message);
                 return false;
               }
+              throw e;
             }
 
       - name: install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -54,7 +54,9 @@ jobs:
             const readFileAsync = (file, enc = 'utf8') => promisify(fs.readFile)(file, enc);
 
             class UnnecessaryException extends Error {
-              constructor() { super('no need unittest in this commit/PR') }
+              constructor() {
+                super(`no need unittest in this ${context.eventName === 'push' ? 'commit' : 'PR'}`);
+              }
             }
 
             try {
@@ -84,7 +86,7 @@ jobs:
               if (!targets.length) throw new UnnecessaryException;
 
               // extract written links
-              const pickLinks = async (file, pickedLinks) => { // (string, Set<string>) => void
+              const pickLinks = async (file, pickedLinks) => { // (string, Set<string>) => Promise<void>
                 const text = await readFileAsync(file);
                 const matches = text.match(RegExp(linkPattern, 'g')) || [];
                 const newFiles = matches

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Here is current available options.
 | `--native-call-max-depth` | Specify the max depth to call a native function. 1024 by default.     |
 | `--case-threshold`        | Specify the max interval between case's integer value. 16 by default. |
 |                           |                                                                       |
+| `--exec:repl`             | Run the **Repl**.                                                     |
 | `--exec:spectest`         | Run the **SpecTest**.                                                 |
 
 ## Examples


### PR DESCRIPTION
`on.push.paths` および `on.pull_request.paths` でのトリガーを廃し、 job の中でテストが必要かどうかを判断するように変更しました。
一応申し上げておきますが、必要がないとお考えでしたら容赦なく reject してください。

やっていることですが、

1. push なら一つのコミット分の、 PR なら関連するコミットの diff を取得し、変更のあるファイルリストを生成。
1. リポジトリルートの `.spectest` を参照し、 `root` `topLevelFilePattern` `linkPattern` `interpreter` `ignoreFiles` を取得。
1. `.spectest` の内容に基づき `root` ディレクトリから `topLevelFilePattern` に合致するファイルを取得。
1. 上で確定したファイルを読み込み、 `linkPattern` に一致する内容からリンクのパスを取得。
1. 4 で得られたパスを起点として 3～4 を繰り返す。
1. 全ての辿れるリンクの中に、 1 で得られたリストの中にある diff が含まれていたらテストを実施。そうでなければテストをスルー。

です。

---

なお、おまけで `README.md` に `--exec:repl` オプションを追加しました。