### PR TITLE
mark libssh2 with 'vendored' for ignoring by github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 
 # exclude files in directories below from github stats
 src/extlib/libcurl/**   linguist-vendored
+src/extlib/libssh2/**   linguist-vendored
 src/extlib/libxml2/**   linguist-vendored
 src/extlib/onig/**      linguist-vendored
 src/extlib/openssl/**   linguist-vendored


### PR DESCRIPTION
libssh2 追加 ( d2cc75651082ab4191166e2ecd7c7e52c7ba6f4b...0d97afcefa29dba16c0519e763f4594106520ac4 ) に伴う更新です。